### PR TITLE
Fix/sprint1/eunsun

### DIFF
--- a/lib/config/theme/app_colors.dart
+++ b/lib/config/theme/app_colors.dart
@@ -1,18 +1,35 @@
 import 'package:flutter/material.dart';
 
 class AppColors {
-  // primary color
-  static const Color primaryGreen = Color(0xFF037F56);      // 녹색
-  static const Color primaryRed = Color(0xFFEF4452);        // 빨간색
-  static const Color primaryPink = Color(0xFFF56570);       // 분홍색
+  // 주요 색상(Primary Colors)
+  static const Color primaryGreen = Color(0xFF037F56);        // 녹색
+  static const Color primaryRed = Color(0xFFEF4452);          // 빨간색
+  static const Color primaryPink = Color(0xFFF56570);         // 분홍색
+  static const Color primaryPinkDisabled = Color(0xFFF8D6DA); // 비활성화된 분홍색
 
-  // 중립 색상
-  static const Color neutralBlack = Color(0xFF1A1A1C);      // 거의 검정색
-  static const Color neutralDarkGray = Color(0xFF4D4D4D);   // 어두운 회색
-  static const Color neutralGray = Color(0xFF707070);       // 중간 회색
-  static const Color neutralMediumGray = Color(0xFFC0C0C0); // 중간-밝은 회색
-  static const Color neutralLightGray = Color(0xFFD9D9D9);  // 밝은 회색
-  static const Color neutralGhost = Color(0xFFF5F5F5);      // 거의 흰색 (배경용)
-  static const Color neutralWhite = Color(0xFFFFFFFF);      // 흰색
+  // 중립 색상(Grayscale Colors)
+  static const Color grayscale1 = Color(0xFF1A1A1C);  // 거의 검정색
+  static const Color grayscale2 = Color(0xFF4D4D4D);  // 어두운 회색
+  static const Color grayscale3 = Color(0xFF707070);  // 중간 회색
+  static const Color grayscale4 = Color(0xFFC0C0C0);  // 중간-밝은 회색
+  static const Color grayscale5 = Color(0xFFD9D9D9);  // 밝은 회색
+  static const Color grayscale6 = Color(0xFFECECEC);  // 더 밝은 회색
+  static const Color grayscale7 = Color(0xFFF5F5F5);  // 거의 흰색 (배경용)
+  static const Color grayscale8 = Color(0xFFFFFFFF);  // 흰색
 
+  // 시스템 색상(System Colors) - 위험(Danger), 빨간색
+  static const Color systemDangerText = Color(0xFFD50136);  // 위험 텍스트 색상
+  static const Color systemDanger = Color(0xFFEB003B);      // 위험 배경/아이콘 색상
+
+  // 시스템 색상(System Colors) - 경고(Warning), 노란색
+  static const Color systemWarningText = Color(0xFF98690A); // 경고 텍스트 색상
+  static const Color systemWarning = Color(0xFFFFB724);     // 경고 배경/아이콘 색상
+
+  // 시스템 색상(System Colors) - 성공(Success), 녹색
+  static const Color systemSuccessText = Color(0xFF006E18); // 성공 텍스트 색상
+  static const Color systemSuccess = Color(0xFF008A1E);     // 성공 배경/아이콘 색상
+
+  // 시스템 색상(System Colors) - 정보(Information), 파란색
+  static const Color systemInfoText = Color(0xFF1F53CC);    // 정보 텍스트 색상
+  static const Color systemInfo = Color(0xFF2768FF);        // 정보 배경/아이콘 색상
 }

--- a/lib/config/theme/app_text_styles.dart
+++ b/lib/config/theme/app_text_styles.dart
@@ -7,86 +7,86 @@ class AppTextStyles {
   static final TextStyle display1 = TextStyle(
     fontFamily: 'PretendardVariable',
     fontSize: 40.sp,
-    color: AppColors.neutralBlack,
+    color: AppColors.grayscale1,
     height: 1.4,
     fontVariations: <FontVariation>[FontVariation('wght', 400)],
   );
   static final TextStyle display1Bold = TextStyle(
     fontFamily: 'PretendardVariable',
     fontSize: 40.sp,
-    color: AppColors.neutralBlack,
+    color: AppColors.grayscale1,
     fontVariations: <FontVariation>[FontVariation('wght', 600)],
   );
 
   static final TextStyle heading1 = TextStyle(
     fontFamily: 'PretendardVariable',
     fontSize: 34.sp,
-    color: AppColors.neutralBlack,
+    color: AppColors.grayscale1,
     fontVariations: <FontVariation>[FontVariation('wght', 400)],
   );
   static final TextStyle heading1Bold = TextStyle(
     fontFamily: 'PretendardVariable',
     fontSize: 34.sp,
-    color: AppColors.neutralBlack,
+    color: AppColors.grayscale1,
     fontVariations: <FontVariation>[FontVariation('wght', 600)],
   );
   static final TextStyle heading2 = TextStyle(
     fontFamily: 'PretendardVariable',
     fontSize: 28.sp,
-    color: AppColors.neutralBlack,
+    color: AppColors.grayscale1,
     fontVariations: <FontVariation>[FontVariation('wght', 400)],
   );
   static final TextStyle heading2Bold = TextStyle(
     fontFamily: 'PretendardVariable',
     fontSize: 28.sp,
-    color: AppColors.neutralBlack,
+    color: AppColors.grayscale1,
     fontVariations: <FontVariation>[FontVariation('wght', 600)],
   );
   static final TextStyle heading3 = TextStyle(
     fontFamily: 'PretendardVariable',
     fontSize: 22.sp,
-    color: AppColors.neutralBlack,
+    color: AppColors.grayscale1,
     fontVariations: <FontVariation>[FontVariation('wght', 400)],
   );
   static final TextStyle heading3Bold = TextStyle(
     fontFamily: 'PretendardVariable',
     fontSize: 22.sp,
-    color: AppColors.neutralBlack,
+    color: AppColors.grayscale1,
     fontVariations: <FontVariation>[FontVariation('wght', 600)],
   );
   static final TextStyle heading4 = TextStyle(
     fontFamily: 'PretendardVariable',
     fontSize: 20.sp,
-    color: AppColors.neutralBlack,
+    color: AppColors.grayscale1,
     fontVariations: <FontVariation>[FontVariation('wght', 400)],
   );
   static final TextStyle heading4Bold = TextStyle(
     fontFamily: 'PretendardVariable',
     fontSize: 20.sp,
-    color: AppColors.neutralBlack,
+    color: AppColors.grayscale1,
     fontVariations: <FontVariation>[FontVariation('wght', 600)],
   );
 
   static final TextStyle body1 = TextStyle(
     fontFamily: 'PretendardVariable',
     fontSize: 17.sp,
-    color: AppColors.neutralBlack,
+    color: AppColors.grayscale1,
     fontVariations: <FontVariation>[FontVariation('wght', 400)],
   );
   static final TextStyle body1Bold = TextStyle(
     fontFamily: 'PretendardVariable',
     fontSize: 17.sp,
-    color: AppColors.neutralBlack,
+    color: AppColors.grayscale1,
     fontVariations: <FontVariation>[FontVariation('wght', 600)],
   );
   static final TextStyle body2 = TextStyle(
     fontFamily: 'PretendardVariable',
     fontSize: 16.sp,
-    color: AppColors.neutralBlack,
+    color: AppColors.grayscale1,
     fontVariations: <FontVariation>[FontVariation('wght', 400)],
   );
   static final TextStyle body2Bold = TextStyle(
-    color: AppColors.neutralBlack,
+    color: AppColors.grayscale1,
     fontFamily: 'PretendardVariable',
     fontSize: 16.sp,
     fontVariations: <FontVariation>[FontVariation('wght', 600)],
@@ -94,49 +94,49 @@ class AppTextStyles {
   static final TextStyle body3 = TextStyle(
     fontFamily: 'PretendardVariable',
     fontSize: 15.sp,
-    color: AppColors.neutralBlack,
+    color: AppColors.grayscale1,
     fontVariations: <FontVariation>[FontVariation('wght', 400)],
   );
   static final TextStyle body3Bold = TextStyle(
     fontFamily: 'PretendardVariable',
     fontSize: 15.sp,
-    color: AppColors.neutralBlack,
+    color: AppColors.grayscale1,
     fontVariations: <FontVariation>[FontVariation('wght', 600)],
   );
   static final TextStyle body4 = TextStyle(
     fontFamily: 'PretendardVariable',
     fontSize: 13.sp,
-    color: AppColors.neutralBlack,
+    color: AppColors.grayscale1,
     fontVariations: <FontVariation>[FontVariation('wght', 400)],
   );
   static final TextStyle body4Bold = TextStyle(
     fontFamily: 'PretendardVariable',
     fontSize: 13.sp,
-    color: AppColors.neutralBlack,
+    color: AppColors.grayscale1,
     fontVariations: <FontVariation>[FontVariation('wght', 600)],
   );
   static final TextStyle body5 = TextStyle(
     fontFamily: 'PretendardVariable',
     fontSize: 12.sp,
-    color: AppColors.neutralBlack,
+    color: AppColors.grayscale1,
     fontVariations: <FontVariation>[FontVariation('wght', 400)],
   );
   static final TextStyle body5Bold = TextStyle(
     fontFamily: 'PretendardVariable',
     fontSize: 12.sp,
-    color: AppColors.neutralBlack,
+    color: AppColors.grayscale1,
     fontVariations: <FontVariation>[FontVariation('wght', 600)],
   );
   static final TextStyle body6 = TextStyle(
     fontFamily: 'PretendardVariable',
     fontSize: 11.sp,
-    color: AppColors.neutralBlack,
+    color: AppColors.grayscale1,
     fontVariations: <FontVariation>[FontVariation('wght', 400)],
   );
   static final TextStyle body6Bold = TextStyle(
     fontFamily: 'PretendardVariable',
     fontSize: 11.sp,
-    color: AppColors.neutralBlack,
+    color: AppColors.grayscale1,
     fontVariations: <FontVariation>[FontVariation('wght', 600)],
   );
 
@@ -144,62 +144,62 @@ class AppTextStyles {
   static final TextStyle display1White = TextStyle(
     fontFamily: 'PretendardVariable',
     fontSize: 40.sp,
-    color: AppColors.neutralWhite,
+    color: AppColors.grayscale8,
     fontVariations: <FontVariation>[FontVariation('wght', 400)],
   );
   static final TextStyle display1BoldWhite = TextStyle(
     fontFamily: 'PretendardVariable',
     fontSize: 40.sp,
-    color: AppColors.neutralWhite,
+    color: AppColors.grayscale8,
     fontVariations: <FontVariation>[FontVariation('wght', 600)],
   );
 
   static final TextStyle heading1White = TextStyle(
     fontFamily: 'PretendardVariable',
     fontSize: 34.sp,
-    color: AppColors.neutralWhite,
+    color: AppColors.grayscale8,
     fontVariations: <FontVariation>[FontVariation('wght', 400)],
   );
   static final TextStyle heading1BoldWhite = TextStyle(
     fontFamily: 'PretendardVariable',
     fontSize: 34.sp,
-    color: AppColors.neutralWhite,
+    color: AppColors.grayscale8,
     fontVariations: <FontVariation>[FontVariation('wght', 600)],
   );
   static final TextStyle heading2White = TextStyle(
     fontFamily: 'PretendardVariable',
     fontSize: 28.sp,
-    color: AppColors.neutralWhite,
+    color: AppColors.grayscale8,
     fontVariations: <FontVariation>[FontVariation('wght', 400)],
   );
   static final TextStyle heading2BoldWhite = TextStyle(
     fontFamily: 'PretendardVariable',
     fontSize: 28.sp,
-    color: AppColors.neutralWhite,
+    color: AppColors.grayscale8,
     fontVariations: <FontVariation>[FontVariation('wght', 600)],
   );
   static final TextStyle heading3White = TextStyle(
     fontFamily: 'PretendardVariable',
     fontSize: 22.sp,
-    color: AppColors.neutralWhite,
+    color: AppColors.grayscale8,
     fontVariations: <FontVariation>[FontVariation('wght', 400)],
   );
   static final TextStyle heading3BoldWhite = TextStyle(
     fontFamily: 'PretendardVariable',
     fontSize: 22.sp,
-    color: AppColors.neutralWhite,
+    color: AppColors.grayscale8,
     fontVariations: <FontVariation>[FontVariation('wght', 600)],
   );
   static final TextStyle heading4White = TextStyle(
     fontFamily: 'PretendardVariable',
     fontSize: 20.sp,
-    color: AppColors.neutralWhite,
+    color: AppColors.grayscale8,
     fontVariations: <FontVariation>[FontVariation('wght', 400)],
   );
   static final TextStyle heading4BoldWhite = TextStyle(
     fontFamily: 'PretendardVariable',
     fontSize: 20.sp,
-    color: AppColors.neutralWhite,
+    color: AppColors.grayscale8,
     fontVariations: <FontVariation>[FontVariation('wght', 600)],
   );
 
@@ -207,23 +207,23 @@ class AppTextStyles {
   static final TextStyle body1White = TextStyle(
     fontFamily: 'PretendardVariable',
     fontSize: 17.sp,
-    color: AppColors.neutralWhite,
+    color: AppColors.grayscale8,
     fontVariations: <FontVariation>[FontVariation('wght', 400)],
   );
   static final TextStyle body1BoldWhite = TextStyle(
     fontFamily: 'PretendardVariable',
     fontSize: 17.sp,
-    color: AppColors.neutralWhite,
+    color: AppColors.grayscale8,
     fontVariations: <FontVariation>[FontVariation('wght', 600)],
   );
   static final TextStyle body2White = TextStyle(
     fontFamily: 'PretendardVariable',
     fontSize: 16.sp,
-    color: AppColors.neutralWhite,
+    color: AppColors.grayscale8,
     fontVariations: <FontVariation>[FontVariation('wght', 400)],
   );
   static final TextStyle body2BoldWhite = TextStyle(
-    color: AppColors.neutralWhite,
+    color: AppColors.grayscale8,
     fontFamily: 'PretendardVariable',
     fontSize: 16.sp,
     fontVariations: <FontVariation>[FontVariation('wght', 600)],
@@ -231,49 +231,49 @@ class AppTextStyles {
   static final TextStyle body3White = TextStyle(
     fontFamily: 'PretendardVariable',
     fontSize: 15.sp,
-    color: AppColors.neutralWhite,
+    color: AppColors.grayscale8,
     fontVariations: <FontVariation>[FontVariation('wght', 400)],
   );
   static final TextStyle body3BoldWhite = TextStyle(
     fontFamily: 'PretendardVariable',
     fontSize: 15.sp,
-    color: AppColors.neutralWhite,
+    color: AppColors.grayscale8,
     fontVariations: <FontVariation>[FontVariation('wght', 600)],
   );
   static final TextStyle body4White = TextStyle(
     fontFamily: 'PretendardVariable',
     fontSize: 13.sp,
-    color: AppColors.neutralWhite,
+    color: AppColors.grayscale8,
     fontVariations: <FontVariation>[FontVariation('wght', 400)],
   );
   static final TextStyle body4BoldWhite = TextStyle(
     fontFamily: 'PretendardVariable',
     fontSize: 13.sp,
-    color: AppColors.neutralWhite,
+    color: AppColors.grayscale8,
     fontVariations: <FontVariation>[FontVariation('wght', 600)],
   );
   static final TextStyle body5White = TextStyle(
     fontFamily: 'PretendardVariable',
     fontSize: 12.sp,
-    color: AppColors.neutralWhite,
+    color: AppColors.grayscale8,
     fontVariations: <FontVariation>[FontVariation('wght', 400)],
   );
   static final TextStyle body5BoldWhite = TextStyle(
     fontFamily: 'PretendardVariable',
     fontSize: 12.sp,
-    color: AppColors.neutralWhite,
+    color: AppColors.grayscale8,
     fontVariations: <FontVariation>[FontVariation('wght', 600)],
   );
   static final TextStyle body6White = TextStyle(
     fontFamily: 'PretendardVariable',
     fontSize: 11.sp,
-    color: AppColors.neutralWhite,
+    color: AppColors.grayscale8,
     fontVariations: <FontVariation>[FontVariation('wght', 400)],
   );
   static final TextStyle body6BoldWhite = TextStyle(
     fontFamily: 'PretendardVariable',
     fontSize: 11.sp,
-    color: AppColors.neutralWhite,
+    color: AppColors.grayscale8,
     fontVariations: <FontVariation>[FontVariation('wght', 600)],
   );
 }


### PR DESCRIPTION
## 🛠️ 작업내용

* 기존 컬러 팔레트 이름 수정
![Image](https://github.com/user-attachments/assets/dfba77b9-a602-403e-a0c1-24f703ee2a4a)

* 신규 컬러 팔레트(=시스템 색상) 4종 추가 
![Image](https://github.com/user-attachments/assets/b557d467-4361-46fc-805e-3d2c3f0c0e6a)


## 📜 이슈번호

#21 

## 📢 전달사항
이후 스프린트 명세서에는 색상코드 대신 TextStyle과 AppColors에 저장된 이름이 기재됩니다!
