### PR TITLE
feature/solo-training/solo-pre-recording-page

### DIFF
--- a/lib/config/routes/curriculum_routes.dart
+++ b/lib/config/routes/curriculum_routes.dart
@@ -86,10 +86,11 @@ final List<GoRoute> curriculumRoutes = [
     },
   ),
   GoRoute(
-    path: AppRoutePaths.soloPreRecordingSong,
+    path: "${AppRoutePaths.soloPreRecordingSong}/:trainingMode/:analysisType/:songId",
     name: AppRouteNames.soloPreRecordingSong,
     builder: (context, state) {
       final trainingMode = TrainingMode.values.firstWhere(
+        // 추후 회고 기간 때 수정: 없애기.
         (e) => e.name == state.pathParameters['trainingMode'],
       );
       final analysisType = AnalysisType.values.firstWhere(

--- a/lib/features/curriculum/views/solo_pre_recording_song_page.dart
+++ b/lib/features/curriculum/views/solo_pre_recording_song_page.dart
@@ -1,21 +1,274 @@
-import 'package:flutter/material.dart';
-import 'package:sync2sing/features/shared/logics/analysis_type.dart';
-import 'package:sync2sing/features/shared/logics/training_mode.dart';
+import 'dart:convert';
 
-class SoloPreRecordingSongPage extends StatelessWidget {
+import 'package:flutter/material.dart';
+
+import 'package:flutter/cupertino.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:go_router/go_router.dart';
+import 'package:sync2sing/config/theme/app_text_styles.dart';
+import 'package:sync2sing/features/curriculum/logics/song_detail_model.dart';
+import 'package:sync2sing/features/shared/logics/analysis_type.dart';
+import 'package:sync2sing/features/report/logics/vocal_analysis_submit_provider.dart';
+import 'package:sync2sing/features/shared/logics/training_mode.dart';
+import 'package:sync2sing/features/vocal_analysis/logics/providers/vocal_result_provider.dart';
+import 'package:sync2sing/features/vocal_analysis/views/widgets/music_content_player.dart';
+import 'package:flutter_screenutil/flutter_screenutil.dart';
+import 'package:sync2sing/config/routes/route_names.dart';
+import 'package:sync2sing/config/theme/app_colors.dart';
+import 'package:sync2sing/features/vocal_analysis/logics/providers/audio_recorder_provider.dart';
+import 'package:sync2sing/features/shared/views/page_indicator.dart';
+import 'dart:io';
+
+import '../logics/timed_lyric.dart';
+
+class SoloPreRecordingSongPage extends ConsumerStatefulWidget {
+  // 회고 기간에 수정: vocal_anlaysis 폴더로 이동, trainingMode 없애기.
   final TrainingMode trainingMode;
-  final AnalysisType analysisType;
+  final AnalysisType analysisType; // 아마 analysisType 로 onboarding 역할 아예 대체 가능할 듯.
   final int songId;
 
   const SoloPreRecordingSongPage({
-    super.key,
-    required this.trainingMode,
     required this.analysisType,
+    required this.trainingMode,
     required this.songId,
+    super.key,
   });
 
   @override
+  ConsumerState createState() => _SoloPreRecordingSongPageState();
+}
+
+class _SoloPreRecordingSongPageState extends ConsumerState<SoloPreRecordingSongPage>
+    with WidgetsBindingObserver {
+  Key _playerKey = UniqueKey();
+
+  bool _isButtonEnabled = false;
+  late final SongDetailModel _songDetailModel;
+  final String jsonStr = '''
+  {
+    "status": 200,
+    "message": "솔로 트레이닝 MR 곡 조회에 성공했습니다.",
+    "data": {
+        "id": 1,
+        "title": "Golden",
+        "artist": "HUNXR/X(EJAE, Audrey NUNA, REI AMI)",
+        "voice_type": "SOPRANO",
+        "pitch_note_min": "A3",
+        "pitch_note_max": "C4",
+        "lyrics": [
+        {
+                "line_index": 0,
+                "text": "I'm done hidin'",
+                "start_time": 200
+            },
+             {
+                "line_index": 1,
+                "text": "now I'm shinin'",
+                "start_time": 700
+            },
+             {
+                "line_index": 2,
+                "text": "like I'm born to be",
+                "start_time": 1200
+            },
+             {
+                "line_index": 3,
+                "text": "We dreamin' hard",
+                "start_time": 1700
+            },
+            {
+                "line_index": 4,
+                "text": "we came so far",
+                "start_time": 2000
+            },
+            {
+                "line_index": 5,
+                "text": "now I believe",
+                "start_time": 2500
+            }
+        ],
+        "album_art_url": "https://sync2sing-bucket.s3.ap-northeast-2.amazonaws.com/images/album-cover/5fe33ac0-fd48-4fdb-908a-12441469fea3.jpg",
+        "file_url": "https://sync2sing-bucket.s3.ap-northeast-2.amazonaws.com/audios/mr/27e305f9-ca07-4f53-a15a-94f1b5b0cc89.mp3"
+    }
+}
+''';
+
+  @override
+  void initState() {
+    super.initState();
+    WidgetsBinding.instance.addObserver(this);
+
+    if (widget.analysisType == AnalysisType.guest) {
+      // guest -> 온보딩처럼 -> 걍 가져오기
+      // context.go(AppRoutePaths.onboardingRecordingSong);
+      _songDetailModel = SongDetailModel(
+        1,
+        "Do-Re-Mi Song",
+        "Richard Rodgers",
+        "SOPRANO",
+        "C4",
+        "D5",
+        [
+          TimedLyric(0, "(전주중)", 0),
+          TimedLyric(1, "Doe - a deer,", 2300),
+          TimedLyric(2, "a female deer", 4000),
+          TimedLyric(3, "Ray - a drop of golden sun", 6000),
+        ],
+        "https://sync2sing-bucket.s3.ap-northeast-2.amazonaws.com/images/album-cover/5fe33ac0-fd48-4fdb-908a-12441469fea3.jpg",
+        "assets/songs/audios/doremi_song_v3_mr.wav",
+      );
+    } else {
+      Map<String, dynamic> decoded = jsonDecode(jsonStr);
+      _songDetailModel = SongDetailModel.fromJson(decoded);
+    }
+  }
+
+  @override
+  void dispose() {
+    WidgetsBinding.instance.removeObserver(this);
+    super.dispose();
+  }
+
+  @override
+  void didChangeAppLifecycleState(AppLifecycleState state) {
+    // 앱을 다시 들어왔고/ 만약 녹음기가 꺼져있다 (녹음 중지를 하지 않고 나간 경우)
+    if (state == AppLifecycleState.resumed && ref.read(audioRecorderProvider.notifier).isStopped) {
+      setState(() {
+        _playerKey = UniqueKey(); // MusicContentPlayer를 완전히 새로고침
+      });
+    }
+  }
+
+  // 하위 위젯에서 bool 값을 전달할 콜백 함수
+  void onChildBoolChanged(bool value) {
+    setState(() {
+      _isButtonEnabled = value;
+    });
+  }
+
+  void storeVocalAnalysisSubmit(ref) {
+    /// vocalAnalysisSubmitProvider 새로고침
+    /// 이전 분석 결과를 초기화하고 새로운 분석 시작
+    ref.refresh(vocalAnalysisSubmitProvider);
+
+    /// 파일 경로 및 정확도 저장
+    final controller = ref.read(audioRecorderProvider.notifier);
+    final pitchAccuracy = controller.pitchAccuracy;
+
+    debugPrint('🎯 pitch 정확도: $pitchAccuracy');
+
+    // VocalResult Provider에 파일 경로 / 음정 및 박자 정확도 저장
+    ref
+        .read(vocalResultProvider.notifier)
+        .setWavFilePath(ref.read(audioRecorderProvider.notifier).getWavFilePath()); // 음성 파일 경로
+    ref.read(vocalResultProvider.notifier).setPitchAccuracy(pitchAccuracy);
+    ref.read(vocalResultProvider.notifier).setRhythmAccuracy(controller.rhythmAccuracy);
+
+    controller.printRhythmAccuracyDetailStatistics();
+
+    /// *** 저장한 것: 파일 경로 및 정확도 조회하기
+    final vocalPitchData = ref.watch(vocalResultProvider);
+    debugPrint(
+      "파일 경로 및 정확도 저장: ${vocalPitchData.wavFilePath} | ${vocalPitchData.pitchAccuracy} | ${vocalPitchData.rhythmAccuracy}",
+    );
+
+    // ★ 실제 파일 존재 및 크기 확인
+    if (vocalPitchData.wavFilePath != null) {
+      final file = File(vocalPitchData.wavFilePath!);
+      debugPrint('→ 실제 파일 존재: ${file.existsSync()}');
+      debugPrint('→ 실제 파일 크기: ${file.lengthSync()}바이트');
+    }
+
+    // audioRecorderProvider 등록 해제
+    ref.invalidate(audioRecorderProvider);
+  }
+
+  @override
   Widget build(BuildContext context) {
-    return Scaffold(body: Center(child: Text("SoloPreRecordingSongPage")));
+    return Scaffold(
+      /// 키보드가 올라와도 화면 크기가 변하지 않도록 설정
+      resizeToAvoidBottomInset: false,
+      body: SafeArea(
+        child: Container(
+          width: double.infinity, // 수평 중앙 정렬
+          padding: EdgeInsets.fromLTRB(0, 12.h, 0, 40.h), // 상하 여백
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.center,
+            children: [
+              (widget.analysisType == AnalysisType.guest)
+                  ? const PageIndicator(currentPage: 5, pageCount: 6) // onboarding 페이지처럼 보이게.
+                  : const PageIndicator(currentPage: 1, pageCount: 2),
+
+              /// 위와 중간 사이 간격
+              /// Spacer는 남은 공간을 균등하게 분배합니다
+              Spacer(),
+
+              /// 중간 콘텐츠 영역
+              /// 음악 플레이어와 시각화가 들어가는 메인 영역
+              Container(
+                width: 327.w,
+                height: 556.h,
+                padding: EdgeInsets.fromLTRB(16.h, 16.h, 16.h, 20.h),
+                decoration: BoxDecoration(
+                  borderRadius: BorderRadius.circular(10.r),
+                  color: AppColors.grayscale6, // 연한 회색 배경
+                ),
+                child: MusicContentPlayer(
+                  _songDetailModel,
+                  'assets/songs/datas/doremi_song_piano_v2.json', // 백엔드에 음정 박자 모델 파일 경로 추가 필요.
+                  onChildBoolChanged,
+                  key: _playerKey,
+                ),
+              ),
+
+              /// 중간과 버튼 사이 간격
+              Spacer(),
+
+              /// 하단 버튼
+              /// 보컬 분석 리포트 생성 버튼
+              SizedBox(
+                width: 327.w,
+                height: 50.w,
+                child: Consumer(
+                  builder: (context, ref, child) {
+                    return CupertinoButton(
+                      /// 버튼 색상 설정
+                      /// 활성화 시: 분홍색, 비활성화 시: 연한 분홍색
+                      color: AppColors.primaryPink,
+                      disabledColor: AppColors.primaryPinkDisabled,
+                      borderRadius: BorderRadius.circular(10.w),
+
+                      /// 버튼 클릭 시 동작
+                      /// 활성화 조건을 만족하면 분석 로딩 페이지로 이동
+                      onPressed:
+                          _isButtonEnabled
+                              ? () async {
+                                // 데이터 저장
+                                storeVocalAnalysisSubmit(ref);
+
+                                context.go(
+                                  AppRoutePaths
+                                      .vocalAnalysisLoading, // /${widget.trainingMode}/${widget.analysisType}
+                                );
+                              }
+                              : null,
+                      // 비활성화 시 null (클릭 불가)
+                      child: Text(
+                        "보컬 분석 리포트 생성하기",
+                        style:
+                            _isButtonEnabled
+                                ? AppTextStyles
+                                    .body1BoldWhite // 활성화: 굵은 흰색
+                                : AppTextStyles.body1White, // 비활성화: 일반 흰색
+                      ),
+                    );
+                  },
+                ),
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
   }
 }

--- a/lib/features/vocal_analysis/views/pages/onboarding_recording_song_page.dart
+++ b/lib/features/vocal_analysis/views/pages/onboarding_recording_song_page.dart
@@ -3,15 +3,18 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
 import 'package:sync2sing/config/theme/app_text_styles.dart';
+import 'package:sync2sing/features/curriculum/logics/song_detail_model.dart';
+import 'package:sync2sing/features/curriculum/logics/timed_lyric.dart';
 import 'package:sync2sing/features/report/logics/vocal_analysis_submit_provider.dart';
 import 'package:sync2sing/features/vocal_analysis/logics/providers/vocal_result_provider.dart';
-import '../widgets/music_content_player.dart';
 import 'package:flutter_screenutil/flutter_screenutil.dart';
 import 'package:sync2sing/config/routes/route_names.dart';
 import 'package:sync2sing/config/theme/app_colors.dart';
 import 'package:sync2sing/features/vocal_analysis/logics/providers/audio_recorder_provider.dart';
 import 'package:sync2sing/features/shared/views/page_indicator.dart';
 import 'dart:io';
+
+import '../widgets/music_content_player.dart';
 
 /// 온보딩 과정의 녹음 페이지
 ///
@@ -34,6 +37,23 @@ class OnboardingRecordingSongPage extends ConsumerStatefulWidget {
 class _OnboardingRecordingSongPageState extends ConsumerState<OnboardingRecordingSongPage>
     with WidgetsBindingObserver {
   Key _playerKey = UniqueKey();
+  bool _isButtonEnabled = false;
+  late final SongDetailModel _songDetailModel = SongDetailModel(
+    1,
+    "Do-Re-Mi Song",
+    "Richard Rodgers",
+    "SOPRANO",
+    "C4",
+    "D5",
+    [
+      TimedLyric(0, "(전주중)", 0),
+      TimedLyric(1, "Doe - a deer,", 2300),
+      TimedLyric(2, "a female deer", 4000),
+      TimedLyric(3, "Ray - a drop of golden sun", 6000),
+    ],
+    "https://sync2sing-bucket.s3.ap-northeast-2.amazonaws.com/images/album-cover/5fe33ac0-fd48-4fdb-908a-12441469fea3.jpg",
+    "assets/songs/audios/doremi_song_v3_mr.wav", // 백엔드에 저장된 파일과 음정 박자 파일 불일치 -> asset 사용. 다만 길이 조정 필요 (음악 끝나기 전까지 다음버튼 클릭 불가)
+  );
 
   @override
   void initState() {
@@ -57,15 +77,11 @@ class _OnboardingRecordingSongPageState extends ConsumerState<OnboardingRecordin
     }
   }
 
-  /// 보컬 분석 버튼 활성화 조건을 확인하는 함수
-  ///
-  /// 현재는 항상 true를 반환하지만, 추후 다음 조건들을 추가할 수 있습니다:
-  /// - 최소 녹음 시간 달성 여부
-  /// - 음정 정확도 기준 달성 여부
-  /// - 필수 구간 녹음 완료 여부
-  bool isVocalAnalysisButtonEnabled() {
-    // 보컬 분석 버튼 활성화 조건
-    return true;
+  // 하위 위젯에서 bool 값을 전달할 콜백 함수
+  void onChildBoolChanged(bool value) {
+    setState(() {
+      _isButtonEnabled = value;
+    });
   }
 
   void storeVocalAnalysisSubmit(ref) {
@@ -130,16 +146,23 @@ class _OnboardingRecordingSongPageState extends ConsumerState<OnboardingRecordin
               /// 음악 플레이어와 시각화가 들어가는 메인 영역
               Container(
                 width: 327.w,
+                height: 556.h,
                 padding: EdgeInsets.fromLTRB(16.h, 16.h, 16.h, 20.h),
-                constraints: BoxConstraints(minHeight: 300.h),
+                // constraints: BoxConstraints(minHeight: 300.h),
                 decoration: BoxDecoration(
                   borderRadius: BorderRadius.circular(10.r),
-                  color: const Color(0xFFECECEC), // 연한 회색 배경
+                  color: AppColors.grayscale6,
                 ),
 
                 /// MusicContentPlayer: 음악 재생, 녹음, 시각화를 담당하는 핵심 위젯
                 /// 이 위젯에서 모든 음악 관련 기능이 처리됩니다
-                child: MusicContentPlayer(key: _playerKey),
+                // child: MusicContentPlayer(key: _playerKey),
+                child: MusicContentPlayer(
+                  _songDetailModel,
+                  'assets/songs/datas/doremi_song_piano_v2.json',
+                  onChildBoolChanged,
+                  key: _playerKey,
+                ),
               ),
 
               /// 중간과 버튼 사이 간격
@@ -162,7 +185,7 @@ class _OnboardingRecordingSongPageState extends ConsumerState<OnboardingRecordin
                       /// 버튼 클릭 시 동작
                       /// 활성화 조건을 만족하면 분석 로딩 페이지로 이동
                       onPressed:
-                          isVocalAnalysisButtonEnabled()
+                          _isButtonEnabled
                               ? () async {
                                 // 데이터 저장
                                 storeVocalAnalysisSubmit(ref);
@@ -176,7 +199,7 @@ class _OnboardingRecordingSongPageState extends ConsumerState<OnboardingRecordin
                       child: Text(
                         "보컬 분석 리포트 생성하기",
                         style:
-                            isVocalAnalysisButtonEnabled()
+                            _isButtonEnabled
                                 ? AppTextStyles
                                     .body1BoldWhite // 활성화: 굵은 흰색
                                 : AppTextStyles.body1White, // 비활성화: 일반 흰색

--- a/lib/features/vocal_analysis/views/widgets/lyrics_display_widget.dart
+++ b/lib/features/vocal_analysis/views/widgets/lyrics_display_widget.dart
@@ -1,21 +1,41 @@
 import 'package:flutter/material.dart';
 import 'package:sync2sing/config/theme/app_colors.dart';
 import 'package:sync2sing/config/theme/app_text_styles.dart';
+import 'package:sync2sing/features/curriculum/logics/timed_lyric.dart';
 
-class LyricsSection extends StatefulWidget {
-  const LyricsSection({super.key});
+class LyricsSection extends StatelessWidget {
+  final List<TimedLyric> lyrics;
+  final Duration currentPosition;
+  const LyricsSection({super.key, required this.lyrics, required this.currentPosition});
 
-  @override
-  State<LyricsSection> createState() => _LyricsSectionState();
-}
-
-class _LyricsSectionState extends State<LyricsSection> {
   @override
   Widget build(BuildContext context) {
-    return Text(
-      "(전주중) \nDoe - a deer, \na female deer \nRay - a drop of golden sun",
-      style: AppTextStyles.heading1Bold.copyWith(color: AppColors.grayscale3),
-      textAlign: TextAlign.center,
+    // 현재 위치에 맞는 가사 인덱스를 찾음
+    int currentLyricIndex = -1; // 시작: 아무 텍스트도 색 바꾸지 x
+    for (int i = 0; i < lyrics.length; i++) {
+      if (currentPosition.inMilliseconds >= lyrics[i].startTime) {
+        currentLyricIndex = i;
+      } else {
+        break;
+      }
+    }
+
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.center,
+      children:
+          lyrics.asMap().entries.map((entry) {
+            int idx = entry.key;
+            TimedLyric item = entry.value;
+
+            // 현재 가사일 경우 색상 변경
+            final color = (idx == currentLyricIndex) ? AppColors.grayscale3 : AppColors.grayscale4;
+
+            return Text(
+              item.text,
+              style: AppTextStyles.heading2Bold.copyWith(color: color),
+              textAlign: TextAlign.center,
+            );
+          }).toList(),
     );
   }
 }

--- a/lib/features/vocal_analysis/views/widgets/music_content_player.dart
+++ b/lib/features/vocal_analysis/views/widgets/music_content_player.dart
@@ -7,7 +7,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_screenutil/flutter_screenutil.dart';
 import 'package:just_audio/just_audio.dart';
 import 'package:sync2sing/config/theme/app_colors.dart';
-import 'package:sync2sing/config/theme/app_text_styles.dart';
+import 'package:sync2sing/features/curriculum/logics/song_detail_model.dart';
 import 'package:sync2sing/features/vocal_analysis/views/widgets/lyrics_display_widget.dart';
 import 'song_information_widget.dart';
 import 'pitch_and_rhythm_bar.dart';
@@ -27,7 +27,16 @@ import 'package:flutter/services.dart' show rootBundle;
 // 6. BPM 기반 막대 이동속도 조절
 
 class MusicContentPlayer extends ConsumerStatefulWidget {
-  const MusicContentPlayer({super.key});
+  final SongDetailModel songDetailModel;
+  final String pitchRhythmJsonPath;
+  final ValueChanged<bool> onButtonEnabledChanged; // 보분리 생성 버튼 enabled 여부 콜백 함수.
+
+  const MusicContentPlayer(
+    this.songDetailModel,
+    this.pitchRhythmJsonPath,
+    this.onButtonEnabledChanged, {
+    super.key,
+  });
 
   @override
   ConsumerState createState() => _MusicContentPlayerState();
@@ -47,6 +56,15 @@ class _MusicContentPlayerState extends ConsumerState<MusicContentPlayer>
   int? _userCurrentPitch; // 사용자 현재 음정
   Timer? _pitchDetectionTimer; // 일정한 간격을 두고 음정을 감지하는 도구
   Timer? _testTimer; // 테스트용 타이머 (오디오 없이 position 시뮬레이션)
+
+  // 일정 시간 지나면 콜백 함수 실행: 버튼 활성화
+  Timer? _enableButtonTimer;
+  final int _enableTimeMs = 3000; // 버튼활성화 시점(ms)
+  /// 재생 버튼 누른 후 시간
+  int _elapsedMillis = 0;
+
+  /// 누적 시간 (ms 단위)
+  bool _buttonEnabledAlready = false; // 3초 콜백이 이미 실행됐는지 체크
 
   // 위젯이 처음 실행될 때 실행되는 초기화 함수
   @override
@@ -81,7 +99,12 @@ class _MusicContentPlayerState extends ConsumerState<MusicContentPlayer>
     _audioPlayer = AudioPlayer();
     try {
       // MR 불러오기
-      await _audioPlayer.setAsset('assets/songs/audios/doremi_song_v3_mr.wav');
+      if (widget.songDetailModel.fileUrl.startsWith("assets")) {
+        await _audioPlayer.setAsset(widget.songDetailModel.fileUrl);
+      } else {
+        await _audioPlayer.setUrl(widget.songDetailModel.fileUrl);
+      }
+      //
       debugPrint('MR 불러오기 성공');
     } catch (e) {
       debugPrint('MR 불러오기 실패: $e');
@@ -107,9 +130,13 @@ class _MusicContentPlayerState extends ConsumerState<MusicContentPlayer>
     // MR 재생이 끝나면 자동으로 처음으로 돌아간 뒤 일시정지
     _audioPlayer.playerStateStream.listen((playerState) {
       if (playerState.processingState == ProcessingState.completed) {
-        setState(() => _isPlaying = false);
         _audioPlayer.seek(Duration.zero); // 처음으로 돌아가기
+        _audioPlayer.pause();
         ref.read(audioRecorderProvider.notifier).pause(); // 녹음 정지
+        setState(() {
+          _isPlaying = false;
+        });
+        debugPrint("currentPosition: ${ref.watch(audioPositionProvider)}");
         debugPrint('MR 재생 완료, 처음으로 돌아감');
       }
     });
@@ -127,9 +154,7 @@ class _MusicContentPlayerState extends ConsumerState<MusicContentPlayer>
   Future _loadPitchBars() async {
     try {
       // JSON 파일에서 음정/박자 데이터 불러오기
-      final String jsonString = await rootBundle.loadString(
-        'assets/songs/datas/doremi_song_piano_v2.json',
-      );
+      final String jsonString = await rootBundle.loadString(widget.pitchRhythmJsonPath);
       debugPrint('JSON 파일 로딩 성공, 길이: ${jsonString.length}');
 
       final List jsonData = json.decode(jsonString);
@@ -222,13 +247,34 @@ class _MusicContentPlayerState extends ConsumerState<MusicContentPlayer>
 
       debugPrint('🎵 테스트 타이머 - 현재 위치: ${currentPos.inMilliseconds}ms');
 
-      // 30초 후 자동 정지
-      if (currentPos.inSeconds >= 30) {
+      // 12초 후 자동 정지
+      if (currentPos.inSeconds >= 12) {
         timer.cancel();
         setState(() => _isPlaying = false);
         debugPrint('테스트 재생 완료');
       }
     });
+  }
+
+  // 버튼 활성화를 위한 타이머 재기
+  void _startEnableButtonTimer() {
+    // 이미 활성화 됐다면 다시 실행할 필요 없음
+    if (_buttonEnabledAlready) return;
+
+    _enableButtonTimer = Timer.periodic(Duration(milliseconds: 100), (timer) {
+      _elapsedMillis += 100;
+
+      if (_elapsedMillis >= _enableTimeMs && !_buttonEnabledAlready) {
+        _buttonEnabledAlready = true;
+        widget.onButtonEnabledChanged(true);
+        _enableButtonTimer?.cancel();
+      }
+    });
+  }
+
+  void _pauseEnableButtonTimer() {
+    _enableButtonTimer?.cancel();
+    _enableButtonTimer = null;
   }
 
   // MR 재생과 녹음을 동시에 시작/정지하는 함수
@@ -238,6 +284,7 @@ class _MusicContentPlayerState extends ConsumerState<MusicContentPlayer>
       _audioPlayer.pause();
       await ref.read(audioRecorderProvider.notifier).pause();
       setState(() => _isPlaying = false);
+      _pauseEnableButtonTimer(); // 시간 카운트 일시중지
       debugPrint('MR 일시정지 + 녹음 정지');
     } else {
       // 현재 일시정지 상태면 재생 + 녹음 시작
@@ -245,6 +292,7 @@ class _MusicContentPlayerState extends ConsumerState<MusicContentPlayer>
         _audioPlayer.play();
         await ref.read(audioRecorderProvider.notifier).startOrResume();
         setState(() => _isPlaying = true);
+        _startEnableButtonTimer(); // 3초 카운트 시작 (이미 활성화면 무시)
         debugPrint('MR 재생 + 녹음 시작');
       } catch (e) {
         debugPrint('MR 재생 실패: $e');
@@ -256,11 +304,6 @@ class _MusicContentPlayerState extends ConsumerState<MusicContentPlayer>
       }
     }
   }
-
-  // 키 내리기 기능: 추후 구현 예정
-  void _decreaseKey() => debugPrint('키 내리기 기능 실행');
-  // 키 올리기 기능: 추후 구현 예정
-  void _increaseKey() => debugPrint('키 올리기 기능 실행');
 
   @override
   void dispose() {
@@ -324,12 +367,23 @@ class _MusicContentPlayerState extends ConsumerState<MusicContentPlayer>
       crossAxisAlignment: CrossAxisAlignment.center,
       children: [
         // 곡 정보 표시
-        SongInformationWidget(),
+        SongInformationWidget(
+          title: widget.songDetailModel.title,
+          artist: widget.songDetailModel.artist,
+        ),
         // 가사 표시
-        LyricsSection(),
+        Expanded(
+          child: SingleChildScrollView(
+            // 가사가 영역을 초과하면 스크롤 처리. (overflow 방지)
+            child: LyricsSection(
+              lyrics: widget.songDetailModel.lyrics,
+              currentPosition: currentPosition,
+            ),
+          ),
+        ),
         // 음정/박자 막대 표시
         Container(
-          height: 155.h,
+          height: 160.h,
           decoration: BoxDecoration(
             borderRadius: BorderRadiusDirectional.circular(10.r),
             color: AppColors.grayscale7,
@@ -350,21 +404,10 @@ class _MusicContentPlayerState extends ConsumerState<MusicContentPlayer>
         ),
         SizedBox(height: 20.h),
         // 키 조절, 재생/일시정지 버튼 표시
-        SizedBox(
-          width: double.infinity,
-          height: 42.w,
-          child: Row(
-            mainAxisAlignment: MainAxisAlignment.spaceBetween,
-            children: [
-              _KeyControlButton(textContent: "Key -", onPressed: _decreaseKey),
-              // 재생/일시정지 버튼: 상태에 따라 다른 버튼 표시
-              (isRecording || _isPlaying)
-                  ? _PauseButton(onPressed: _togglePlayAndRecord)
-                  : _PlayButton(onPressed: _togglePlayAndRecord),
-              _KeyControlButton(textContent: "Key +", onPressed: _increaseKey),
-            ],
-          ),
-        ),
+        // 재생/일시정지 버튼: 상태에 따라 다른 버튼 표시
+        (isRecording || _isPlaying)
+            ? _PauseButton(onPressed: _togglePlayAndRecord)
+            : _PlayButton(onPressed: _togglePlayAndRecord),
       ],
     );
   }
@@ -404,34 +447,7 @@ class _PauseButton extends StatelessWidget {
       child: ImageIcon(
         AssetImage("assets/images/pause.png"),
         color: AppColors.grayscale3,
-        size: 20.w,
-      ),
-    );
-  }
-}
-
-// 키 조절 버튼 위젯: 추후 구현 예정
-class _KeyControlButton extends StatelessWidget {
-  final String textContent;
-  final VoidCallback onPressed;
-  const _KeyControlButton({required this.textContent, required this.onPressed});
-
-  @override
-  Widget build(BuildContext context) {
-    return SizedBox(
-      width: 98.w,
-      height: 42.h,
-      child: CupertinoButton(
-        padding: EdgeInsets.zero,
-        onPressed: onPressed,
-        borderRadius: BorderRadius.circular(10.r),
-        color: AppColors.grayscale5,
-        minSize: 0.0,
-        child: Text(
-          textContent,
-          textAlign: TextAlign.center,
-          style: AppTextStyles.body1Bold.copyWith(color: AppColors.grayscale3),
-        ),
+        size: 20.h,
       ),
     );
   }

--- a/lib/features/vocal_analysis/views/widgets/song_information_widget.dart
+++ b/lib/features/vocal_analysis/views/widgets/song_information_widget.dart
@@ -4,18 +4,22 @@ import 'package:sync2sing/config/theme/app_colors.dart';
 import 'package:sync2sing/config/theme/app_text_styles.dart';
 
 class SongInformationWidget extends StatelessWidget {
-  const SongInformationWidget({super.key});
+  final String title;
+  final String artist;
+  const SongInformationWidget({super.key, required this.title, required this.artist});
 
   @override
   Widget build(BuildContext context) {
     return Column(
       crossAxisAlignment: CrossAxisAlignment.center,
       children: [
-        Text("Do-Re-Mi Song", style: AppTextStyles.heading4Bold),
-
+        Text(title, style: AppTextStyles.heading4Bold),
         Text(
-          "Sound of Music",
+          artist,
           style: AppTextStyles.body1.copyWith(color: AppColors.grayscale3),
+          softWrap: false, // 여러 줄 x, 한 줄로 제한
+          overflow: TextOverflow.ellipsis, // 텍스트가 너비 초과하면 ... 로 표시
+          maxLines: 1,
         ),
       ],
     );


### PR DESCRIPTION
## 🛠️ 작업내용
- SoloPreRecordingSongPage 구현
<!-- 무엇을 변경하거나 추가했는지 설명해주세요. -->

## 📜 이슈번호
#54 
<!-- #이슈번호를 작성해주세요. -->

## 📢 전달사항

- 시간 변화에 따른 가사 색상 변화 구현
- 시작 후 3초 지난 후에 하단 버튼 활성화
- 가사 영역은 singleChildScroll -> 영역 넘치면 스크롤 가능. (이미지 참고) 
- analysisType이 guest 일 시 상단 페이지 인디케이터 변화 ->  onboardingRecordingSongPage 와 구분x 가능할 듯. 

- 클래스 이름 및 폴더 이름을 회고 기간에 수정할 예정입니다: vocal_analysis 폴더로 변경, pre 삭제. + 인자로 trainingMode도 삭제. 
  - pre이지 않은 상황에서도 사용 가능 / 이미 클래스명에 trainingMode 존재. 
  - 음성 분석 페이지 -> vocal_analysis 로 가야 함. (현재는 exampleVideo 페이지와 함께 머지했을 때 충돌이 어떻게 날지 모르겠어서 미룸) 
 

<img width="256" alt="solo_pre_recording_song_solo_1" src="https://github.com/user-attachments/assets/86c4a6cb-290c-470c-8473-2f8a743a16b1" />
<img width="256"  alt="solo_pre_recording_song_solo_5" src="https://github.com/user-attachments/assets/160614a8-c3fc-4f45-835a-5f5f134c1c88" />
<img width="256"  alt="solo_pre_recording_song_solo_3" src="https://github.com/user-attachments/assets/9488754e-8e3c-46f9-9392-5bc9d5f59855" />
<img width="256"  alt="solo_pre_recording_song_solo_6" src="https://github.com/user-attachments/assets/06a0ebf9-8092-4e2d-8227-4bfea9d7dbad" />


<!-- PR과 관련된 내용 공유 또는 리뷰어에 대한 요청사항을 작성해주세요. -->
