### PR TITLE
feature/solo-training/song-example-video-page

### DIFF
--- a/lib/config/routes/curriculum_routes.dart
+++ b/lib/config/routes/curriculum_routes.dart
@@ -86,10 +86,11 @@ final List<GoRoute> curriculumRoutes = [
     },
   ),
   GoRoute(
-    path: AppRoutePaths.soloPreRecordingSong,
+    path: "${AppRoutePaths.soloPreRecordingSong}/:trainingMode/:analysisType/:songId",
     name: AppRouteNames.soloPreRecordingSong,
     builder: (context, state) {
       final trainingMode = TrainingMode.values.firstWhere(
+        // 추후 회고 기간 때 수정: 없애기.
         (e) => e.name == state.pathParameters['trainingMode'],
       );
       final analysisType = AnalysisType.values.firstWhere(

--- a/lib/features/curriculum/views/song_example_video_page.dart
+++ b/lib/features/curriculum/views/song_example_video_page.dart
@@ -1,8 +1,22 @@
+import 'dart:convert';
+
+import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_screenutil/flutter_screenutil.dart';
+import 'package:go_router/go_router.dart';
+import 'package:sync2sing/config/routes/route_names.dart';
+import 'package:sync2sing/config/theme/app_colors.dart';
+import 'package:sync2sing/config/theme/app_text_styles.dart';
+import 'package:sync2sing/features/curriculum/logics/song_detail_model.dart';
 import 'package:sync2sing/features/shared/logics/analysis_type.dart';
 import 'package:sync2sing/features/shared/logics/training_mode.dart';
+import 'package:sync2sing/features/onboarding/logics/watch_youtube_providers.dart';
+import 'package:sync2sing/features/onboarding/views/youtube_player_widget.dart';
+import 'package:sync2sing/features/shared/views/page_indicator.dart';
+import 'package:youtube_player_flutter/youtube_player_flutter.dart';
 
-class SongExampleVideoPage extends StatelessWidget {
+class SongExampleVideoPage extends ConsumerWidget {
   final TrainingMode trainingMode;
   final AnalysisType analysisType;
   final int songId;
@@ -13,11 +27,143 @@ class SongExampleVideoPage extends StatelessWidget {
     required this.songId,
   });
 
+  final String jsonStr = '''
+  
+  {
+    "status": 200,
+    "message": "솔로 트레이닝 원곡 조회에 성공했습니다.",
+    "data": {
+        "id": 1,
+        "title": "Do-Re-Mi",
+        "artist": "Richard Rodgers",
+        "voice_type": "SOPRANO",
+        "pitch_note_min": "C4",
+        "pitch_note_max": "D5",
+        "lyrics": [
+            {
+                "line_index": 0,
+                "text": "Doe(Do), a deer, a female deer",
+                "start_time": 0
+            },
+            {
+                "line_index": 1,
+                "text": "Ray(Re), a drop of golden sun",
+                "start_time": 7200
+            }
+        ],
+        "album_art_url": "https://sync2sing-bucket.s3.ap-northeast-2.amazonaws.com/images/album-cover/5fe33ac0-fd48-4fdb-908a-12441469fea3.jpg",
+        "file_url": "https://sync2sing-bucket.s3.ap-northeast-2.amazonaws.com/audios/original/6875743e-3955-4067-abed-da1911a6aae1.mp3"
+    }
+  }
+''';
+  final String videoId = "Qy9cj-zwbVY";
+  final int videoStartSec = 42;
+
   @override
-  Widget build(BuildContext context) {
-    debugPrint("${trainingMode.name} | ${trainingMode.apiValue} | $songId");
+  Widget build(BuildContext context, WidgetRef ref) {
+    Map<String, dynamic> decoded = jsonDecode(jsonStr);
+    SongDetailModel songDetail = SongDetailModel.fromJson(decoded);
+    final bool isButtonEnabled = ref.watch(isOnboardingRecordingStartButtonEnabledProvider);
+
     return Scaffold(
-      body: Center(child: Text("SongExampleVideoPage - $trainingMode / $analysisType | $songId")),
+      body: SafeArea(
+        child: Container(
+          alignment: Alignment(0.0, -1.0),
+          margin: EdgeInsets.fromLTRB(0, 12.h, 0, 40.h), // 상하 여백
+          child: SizedBox(
+            width: 327.w,
+            child: Column(
+              mainAxisAlignment: MainAxisAlignment.spaceBetween,
+              crossAxisAlignment: CrossAxisAlignment.center,
+              children: [
+                (analysisType == AnalysisType.guest)
+                    ? PageIndicator(currentPage: 4, pageCount: 6)
+                    : PageIndicator(currentPage: 0, pageCount: 2), // 상단 페이지네이션 위젯
+                Expanded(
+                  child: Column(
+                    mainAxisAlignment: MainAxisAlignment.center,
+                    crossAxisAlignment: CrossAxisAlignment.center,
+                    children: [
+                      Container(
+                        margin: EdgeInsets.fromLTRB(0, 32.h, 0, 20.h),
+                        width: 327.w,
+                        alignment: Alignment(-1.0, -1.0),
+                        child: Column(
+                          crossAxisAlignment: CrossAxisAlignment.start,
+                          children: [
+                            Padding(
+                              // 텍스트 필드 (글씨 안내)
+                              padding: EdgeInsets.symmetric(vertical: 4.h),
+                              child: Text(
+                                switch (analysisType) {
+                                  AnalysisType.guest => "마지막 과정이에요",
+                                  AnalysisType.pre => "훈련 전 진단을 시작합니다",
+                                  AnalysisType.post => "훈련 후 진단을 시작합니다",
+                                },
+                                textAlign: TextAlign.left,
+                                style: AppTextStyles.heading3Bold,
+                              ),
+                            ),
+
+                            Text(
+                              "아래 음원을 듣고 \n후렴구를 똑같이 따라 불러주세요",
+                              textAlign: TextAlign.left,
+                              style: AppTextStyles.heading4,
+                            ),
+                          ],
+                        ),
+                      ),
+                      // 유튜브 영상
+                      Container(
+                        width: 327.w,
+                        margin: EdgeInsets.symmetric(vertical: 20.h),
+                        child: YoutubePlayerWidget(
+                          videoId: videoId, // 도레미송 공식 가사 비디오
+                          // do a deer 부분에서 영상 시작, 자동 재생 금지
+                          flags: YoutubePlayerFlags(autoPlay: false, startAt: videoStartSec),
+                        ),
+                      ),
+                    ],
+                  ),
+                ),
+
+                // 시작하기 버튼
+                Container(
+                  width: double.infinity,
+                  height: 50.w,
+                  margin: EdgeInsets.only(top: 32.h),
+                  alignment: Alignment(0.0, 0.0),
+                  child: CupertinoButton(
+                    color: AppColors.primaryPink,
+                    disabledColor: AppColors.primaryPinkDisabled, // 비활성화 색
+                    borderRadius: BorderRadius.circular(10.r),
+                    padding: EdgeInsets.all(0),
+                    onPressed:
+                        isButtonEnabled
+                            ? () {
+                              context.go(
+                                "${AppRoutePaths.soloPreRecordingSong}/${trainingMode.name}/${analysisType.name}/$songId",
+                                extra: songDetail.id,
+                              );
+                            }
+                            : null,
+                    minSize: 0.0,
+                    child: Center(
+                      child: Text(
+                        "시작하기",
+                        style:
+                            isButtonEnabled
+                                ? AppTextStyles.body1BoldWhite
+                                : AppTextStyles.body1White,
+                      ),
+                    ),
+                  ),
+                ),
+              ],
+            ),
+          ),
+        ),
+      ),
     );
   }
 }


### PR DESCRIPTION
## 🛠️ 작업내용
- SongExampleVideoPage 구현 
- anlysisType에 따른 분기 처리: 훈련 전, 훈련 후, 온보딩 모드 
<!-- 무엇을 변경하거나 추가했는지 설명해주세요. -->

## 📜 이슈번호
#53 
<!-- #이슈번호를 작성해주세요. -->

## 📢 전달사항

- 훈련 전 
<img width="256"  alt="songExampleVideo_solo_1" src="https://github.com/user-attachments/assets/83d1f12a-1e15-4037-84c4-1123b44811bb" />
<img width="256"  alt="songExampleVideo_solo_2" src="https://github.com/user-attachments/assets/9e8d2076-178f-4ae5-a492-8f1582bae2b5" />

- 훈련 후
<img width="256"  alt="songExampleVideo_post_1" src="https://github.com/user-attachments/assets/fe5e9023-3a78-4ea2-b3d0-ab801a8b41a3" />

- 온보딩
<img width="256"  alt="songExampleVideo_guest_1" src="https://github.com/user-attachments/assets/4da6e920-9922-4920-89c1-d45ce9d49f05" />

